### PR TITLE
extend <Input/> for compatibility with modular-forms

### DIFF
--- a/packages/lib/src/components/DatePicker/DatePicker.tsx
+++ b/packages/lib/src/components/DatePicker/DatePicker.tsx
@@ -152,6 +152,13 @@ export const DatePicker = component$<DatePickerProps>(
       }),
     )
 
+    const onFocus$ = $(()=>{
+      if (!isDateEqual(viewDate.value, selectedDate.value)) {
+        viewDate.value = selectedDate.value
+      }
+      isOpen.value = true
+    })
+
     return (
       <div class={twMerge('relative', clsx(className))}>
         {!inline && (
@@ -159,12 +166,7 @@ export const DatePicker = component$<DatePickerProps>(
           <Input
             prefix={<IconCalendarMonthOutline />}
             ref={inputRef}
-            onFocus$={() => {
-              if (!isDateEqual(viewDate.value, selectedDate.value)) {
-                viewDate.value = selectedDate.value
-              }
-              isOpen.value = true
-            }}
+            onFocus$={onFocus$}
             value={selectedDate.value && getFormattedDate(language, selectedDate.value)}
             readOnly
             {...attrs}

--- a/packages/lib/src/components/Input/Input.tsx
+++ b/packages/lib/src/components/Input/Input.tsx
@@ -9,26 +9,37 @@ type InputProps = Omit<PropsOf<'input'>, 'size'> & {
   validationStatus?: ValidationStatus
   suffix?: JSXOutput
   prefix?: JSXOutput
-  onClickPrefix$?: () => void
-  onClickSuffix$?: () => void
+  onClickPrefix$?: QRL<() => void>
+  onClickSuffix$?: QRL<() => void>
+  onChange$?: QRL<() => void>
+  onBlur$?: QRL<() => void>
+  onFocus$?: QRL<() => void>
+  onInput$?: QRL<() => void>
   validationMessage?: JSXOutput
   helper?: JSXOutput
+  value?: string | number | null
 }
 
 export const Input = component$<InputProps>(
   ({
-    label,
-    suffix,
-    prefix,
-    size = 'md' as InputSize,
-    validationStatus,
-    class: classNames,
-    validationMessage,
-    helper,
-    onClickPrefix$,
-    onClickSuffix$,
-    ...props
-  }) => {
+     label,
+     suffix,
+     prefix,
+     size = 'md' as InputSize,
+     validationStatus,
+     class: classNames,
+     validationMessage,
+     helper,
+     onClickPrefix$,
+     onClickSuffix$,
+     onChange$,
+     onBlur$,
+     onFocus$,
+     onInput$,
+     disabled,
+     value,
+     ...props
+   }) => {
     const id = useId()
     const validationWrapperClasses = useComputed$(() =>
       twMerge(
@@ -40,14 +51,14 @@ export const Input = component$<InputProps>(
 
     const { inputClasses, labelClasses } = useInputClasses(
       useComputed$(() => size),
-      useComputed$(() => Boolean(props.disabled)),
+      useComputed$(() => Boolean(disabled)),
       useComputed$(() => validationStatus),
     )
 
-    const input = useSignal(props.value ? String(props.value) : undefined)
+    const input = useSignal(value ? String(value) : undefined)
     useTask$(({ track }) => {
-      const innerValue = track(() => props.value)
-      input.value = props.value ? String(innerValue) : undefined
+      const innerValue = track(() => value)
+      input.value = value ? String(innerValue) : undefined
     })
 
     return (
@@ -67,6 +78,10 @@ export const Input = component$<InputProps>(
             {...props}
             id={id}
             bind:value={props['bind:value'] || input}
+            onInput$={onInput$}
+            onChange$={onChange$}
+            onBlur$={onBlur$}
+            onFocus$={onFocus$}
             class={twMerge(inputClasses.value, prefix && 'pl-10', suffix && 'pr-11')}
           />
           {Boolean(suffix) && (


### PR DESCRIPTION
the input component only works for me with modular forms if event attributes are directly attached and not spread via {...props}.

I also detached the value and disabled attribute from the leftover props as this caused a qwik eslint rule to complain.

this behaviour seems to be different than what one might be used from React - for Qwik, I was enocouraged to not rely on prop spreading.