### PR TITLE
Make binding to textarea optional and support onInput$ method

### DIFF
--- a/packages/lib/src/components/Textarea/Textarea.tsx
+++ b/packages/lib/src/components/Textarea/Textarea.tsx
@@ -1,13 +1,14 @@
-import { PropsOf, Signal, component$, useId, JSXOutput, useComputed$ } from '@builder.io/qwik'
+import { $, component$, JSXOutput, PropsOf, QRL, Signal, useComputed$, useId } from '@builder.io/qwik'
 import { useTextareaClasses } from './composables/use-textarea-classes'
 
 type TextareaProps = PropsOf<'textarea'> & {
-  'bind:value': Signal<string>
+  'bind:value'?: Signal<string>
+  onInput$?: QRL<(value: string) => void>
   label?: string
   footer?: JSXOutput
 }
 
-export const Textarea = component$<TextareaProps>(({ footer, label, required, rows = 4, placeholder, class: classNames, ...props }) => {
+export const Textarea = component$<TextareaProps>(({ ['bind:value']: bindTo, onInput$, footer, label, required, rows = 4, placeholder, class: classNames, ...props }) => {
   const hasFooter = useComputed$(() => !!footer)
   const { textareaClasses, labelClasses, wrapperClasses, footerClasses } = useTextareaClasses(hasFooter)
   const id = useId()
@@ -23,8 +24,19 @@ export const Textarea = component$<TextareaProps>(({ footer, label, required, ro
       </span>
 
       <span class={wrapperClasses.value}>
-        <textarea id={id} class={textareaClasses.value} rows={rows} placeholder={placeholder} {...props} bind:value={props['bind:value']} />
-        {hasFooter.value && <span class={footerClasses.value}>{footer}</span>}
+        <textarea
+          id={id}
+          class={textareaClasses.value}
+          rows={rows}
+          placeholder={placeholder}
+          value={bindTo?.value}
+          onInput$={
+            onInput$ ||
+            (bindTo && $((_, el) => (bindTo.value = el.value)))
+          }
+          {...props}
+        />
+        {hasFooter.value && (<span class={footerClasses.value}>{footer}</span>)}
       </span>
     </label>
   )


### PR DESCRIPTION
In some situations, direct value binding isn’t strictly necessary for the textarea, but it is required due to the current implementation.

  Here is the error:
  ![image](https://github.com/user-attachments/assets/e892e922-06ed-465a-b1d5-0dec22cc6ce1)

In this PR, I made value binding optional. 
Additionally, I added support for the onInput$ method.